### PR TITLE
Add PHP webapp demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -773,3 +773,4 @@ Many thanks to these AI whisperers:
 # License
 
 CC-0
+\n## PHP Example Webapp\nA simple PHP version of the leaderboard application is located in the `php_app` directory. Launch it with any PHP server, e.g. `php -S localhost:8000 -t php_app`. It demonstrates keeping the admin password server-side.

--- a/php_app/index.php
+++ b/php_app/index.php
@@ -1,0 +1,48 @@
+<?php
+session_start();
+$isAdmin = isset($_SESSION['is_admin']) && $_SESSION['is_admin'] === true;
+?>
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Leaderboard PHP</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-8 bg-gray-900 text-gray-100">
+<div class="container mx-auto max-w-xl">
+<h1 class="text-2xl font-bold mb-4">PHP Leaderboard Example</h1>
+<?php if($isAdmin): ?>
+<p class="text-green-400 mb-2">Zalogowano jako admin.</p>
+<button id="logoutBtn" class="bg-red-600 px-3 py-1 rounded text-white mb-4">Wyloguj</button>
+<?php else: ?>
+<div class="mb-4">
+    <input type="text" id="adminLogin" placeholder="Login" class="border p-2 text-black">
+    <input type="password" id="adminPassword" placeholder="Hasło" class="border p-2 text-black">
+    <button id="adminLoginBtn" class="bg-blue-600 px-3 py-1 rounded text-white">Zaloguj jako admin</button>
+</div>
+<?php endif; ?>
+<div id="content">Tu można dodać dalszą część aplikacji (JS jak w oryginale).</div>
+</div>
+<script>
+function adminLogin() {
+    const login = document.getElementById('adminLogin').value;
+    const password = document.getElementById('adminPassword').value;
+    fetch('login.php', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+        body: `login=${encodeURIComponent(login)}&password=${encodeURIComponent(password)}`
+    }).then(r=>r.json()).then(d=>{ if(d.success){location.reload();} else {alert('Błąd logowania');}});
+}
+function logout(){
+    fetch('logout.php').then(()=>location.reload());
+}
+<?php if(!$isAdmin): ?>
+document.getElementById('adminLoginBtn').addEventListener('click', adminLogin);
+<?php else: ?>
+document.getElementById('logoutBtn').addEventListener('click', logout);
+<?php endif; ?>
+</script>
+</body>
+</html>

--- a/php_app/login.php
+++ b/php_app/login.php
@@ -1,0 +1,15 @@
+<?php
+session_start();
+$ADMIN_LOGIN = 'sar3th';
+$ADMIN_PASSWORD = 'Gatewayn95!';
+if($_SERVER['REQUEST_METHOD']==='POST'){
+    $login = $_POST['login'] ?? '';
+    $pass = $_POST['password'] ?? '';
+    if($login === $ADMIN_LOGIN && $pass === $ADMIN_PASSWORD){
+        $_SESSION['is_admin'] = true;
+        echo json_encode(['success'=>true]);
+    } else {
+        echo json_encode(['success'=>false]);
+    }
+}
+?>

--- a/php_app/logout.php
+++ b/php_app/logout.php
@@ -1,0 +1,4 @@
+<?php
+session_start();
+session_destroy();
+?>


### PR DESCRIPTION
## Summary
- add simple PHP-based webapp showing server-side admin login
- note location of new demo in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862de9aaad88320a0162597a83bfa98